### PR TITLE
update purescript-foldable-traversable-0.2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "purescript-arrays"               : "~0.3.0",
     "purescript-maybe"                : "~0.2.1",
-    "purescript-foldable-traversable" : "~0.1.6",
+    "purescript-foldable-traversable" : "~0.2.1",
     "purescript-unfoldable"           : "~0.2.0",
     "purescript-transformers"         : "~0.3.1",
     "purescript-lazy"                 : "~0.1.2",

--- a/src/Data/List/Lazy/List.purs
+++ b/src/Data/List/Lazy/List.purs
@@ -15,7 +15,6 @@ module Data.List.Lazy
   , prepend
   , prepend'
   , repeat
-  , scanl
   , singleton
   , tail
   , take
@@ -61,7 +60,6 @@ module Data.List.Lazy
   prepend     = L.prepend
   prepend'    = L.prepend'
   repeat      = L.repeat
-  scanl       = L.scanl
   singleton   = L.singleton
   tail        = L.tail
   take        = L.take


### PR DESCRIPTION
Hi!

Purescript-foldable-traversable-0.2.1 has scanl, so it conflict with Data.List.Lazy.
I removed scanl from Data.List.Lazy to fix it.

Regards.